### PR TITLE
Minor fix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "illuminate/support": "~4|~5",
         "illuminate/filesystem": "~4|~5",
         "illuminate/console": "~4|~5",
-        "symfony/translation": "~2|~3"
+        "symfony/translation": "~2|~3",
+        "pragmarx/support": "~0.6.12"
     },
 
     "require-dev": {


### PR DESCRIPTION
Fixed class not found

```json
{"error":{"type":"Symfony\\Component\\Debug\\Exception\\FatalErrorException","message":"Class 'PragmaRX\\Support\\ServiceProvider' not found","file":"src\/Vendor\/Laravel\/ServiceProvider.php","line":24}}
```